### PR TITLE
Fix deep null complex attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist
 /node_modules
 npm-debug.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill-delta",
-  "version": "4.2.2-reedsy.1.0.0",
+  "version": "4.2.2-reedsy.1.0.1",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",

--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -9,6 +9,15 @@ function isObject(value: any): boolean {
   return value === Object(value) && !Array.isArray(value);
 }
 
+function isDeepNull(value: any): boolean {
+  if (value == null) return true;
+  if (!isObject(value)) return false;
+  for (const key in value) {
+    if (!isDeepNull(value[key])) return false;
+  }
+  return true;
+}
+
 namespace AttributeMap {
   export function compose(
     a: AttributeMap = {},
@@ -29,7 +38,7 @@ namespace AttributeMap {
     }
     if (!keepNull) {
       attributes = Object.keys(attributes).reduce<AttributeMap>((copy, key) => {
-        if (attributes[key] != null) {
+        if (!isDeepNull(attributes[key])) {
           copy[key] = attributes[key];
         }
         return copy;

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -140,6 +140,15 @@ describe('AttributeMap', function() {
         ).toEqual({complex: {foo: [1, 3]}});
       });
 
+      it('ignores null leaves on new attributes', function() {
+        expect(
+          AttributeMap.compose(
+            undefined,
+            {complex: {foo: null, bar: null}},
+          ),
+        ).toBeUndefined();
+      });
+
       it('deep mix of operations', function() {
         expect(
           AttributeMap.compose(


### PR DESCRIPTION
Complex attributes should have the behaviour that they handle `null`
values recursively. That is:

```javascript
{complex: {foo: null}}
```

is equivalent to:

```javascript
{complex: null}
```

which is itself equivalent to `null`.

This change fixes the `null` check in the attribute compose function,
and checks if the object's leaves are all `null`. If so, then the
attribute itself is removed (if `keepNull == false`).