### PR TITLE
Move "deep" libraries from lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,17 @@
 {
   "name": "@reedsy/quill-delta",
-  "version": "4.2.2-reedsy.1.0.1",
+  "version": "4.2.2-reedsy.1.0.2",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",
   "main": "dist/Delta.js",
   "dependencies": {
+    "fast-deep-equal": "^3.1.3",
     "fast-diff": "1.2.0",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0"
+    "rfdc": "^1.1.4"
   },
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.0",
-    "@types/lodash.isequal": "^4.5.0",
+    "@types/rfdc": "^1.1.0",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",
     "coveralls": "^3.0.11",

--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -1,5 +1,6 @@
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import rfdc from 'rfdc';
+import isEqual from 'fast-deep-equal';
+const cloneDeep = rfdc();
 
 interface AttributeMap {
   [key: string]: any;

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -1,8 +1,9 @@
 import diff from 'fast-diff';
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import rfdc from 'rfdc';
+import isEqual from 'fast-deep-equal';
 import AttributeMap from './AttributeMap';
 import Op from './Op';
+const cloneDeep = rfdc();
 
 const NULL_CHARACTER = String.fromCharCode(0); // Placeholder char for embed in diff()
 


### PR DESCRIPTION
This library imports deep clone and deep equal functionality from
`lodash`.

The `lodash` implementations of this functionality are not particularly
performant, so this change swaps them out for `rfdc` for cloning (~4x
faster) and `fast-deep-equal` for deep equality (~7x faster).

This has the combined effect of making a `Delta.transform` ~3-4x faster.