### PR TITLE
🐛 Remove deep `null` when composing complex attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/quill-delta",
-  "version": "5.1.0-reedsy.2.1.0",
+  "version": "5.1.0-reedsy.2.1.1",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",

--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -19,6 +19,16 @@ function isDeepNull(value: unknown): boolean {
   return true;
 }
 
+function removeNull<T>(value: T): T {
+  if (!value || !isObject(value)) return value;
+  for (const key in value) {
+    const k = key as keyof typeof value;
+    if (value[k] == null) delete value[k];
+    else removeNull(value[k]);
+  }
+  return value;
+}
+
 namespace AttributeMap {
   export function compose(
     a: AttributeMap = {},
@@ -42,7 +52,7 @@ namespace AttributeMap {
     if (!keepNull) {
       attributes = Object.keys(attributes).reduce<AttributeMap>((copy, key) => {
         if (!isDeepNull(attributes[key])) {
-          copy[key] = attributes[key];
+          copy[key] = removeNull(attributes[key]);
         }
         return copy;
       }, {});

--- a/test/attributes.ts
+++ b/test/attributes.ts
@@ -144,6 +144,50 @@ describe('AttributeMap', () => {
           },
         });
       });
+
+      it('composing objects with deep null and keepNull=false', function () {
+        expect(
+          AttributeMap.compose(
+            {
+              complex: {
+                foo: {
+                  bar: null,
+                },
+              },
+            },
+            {
+              complex: {
+                foo: {
+                  baz: 123,
+                },
+              },
+            },
+            false,
+          ),
+        ).toEqual({
+          complex: {
+            foo: {
+              baz: 123,
+            },
+          },
+        });
+      });
+
+      it('composing arrays with deep null and keepNull=false', function () {
+        expect(
+          AttributeMap.compose(
+            {
+              complex: [1, 2, 3],
+            },
+            {
+              complex: [null],
+            },
+            false,
+          ),
+        ).toEqual({
+          complex: [null],
+        });
+      });
     });
   });
 
@@ -306,37 +350,37 @@ describe('AttributeMap', () => {
 
     describe('complex attribute', function () {
       it('add property', function () {
-        var attributes = { complex: { bar: 456 } };
-        var base = { complex: { foo: 123 } };
-        var expected = { complex: { bar: null } };
+        const attributes = { complex: { bar: 456 } };
+        const base = { complex: { foo: 123 } };
+        const expected = { complex: { bar: null } };
         expect(AttributeMap.invert(attributes, base)).toEqual(expected);
       });
 
       it('remove property', function () {
-        var attributes = { complex: { bar: null } };
-        var base = { complex: { foo: 123, bar: 456 } };
-        var expected = { complex: { bar: 456 } };
+        const attributes = { complex: { bar: null } };
+        const base = { complex: { foo: 123, bar: 456 } };
+        const expected = { complex: { bar: 456 } };
         expect(AttributeMap.invert(attributes, base)).toEqual(expected);
       });
 
       it('update existing property', function () {
-        var attributes = { complex: { foo: 789 } };
-        var base = { complex: { foo: 123, bar: 456 } };
-        var expected = { complex: { foo: 123 } };
+        const attributes = { complex: { foo: 789 } };
+        const base = { complex: { foo: 123, bar: 456 } };
+        const expected = { complex: { foo: 123 } };
         expect(AttributeMap.invert(attributes, base)).toEqual(expected);
       });
 
       it('array', function () {
-        var attributes = { complex: { foo: [1, 3] } };
-        var base = { complex: { foo: [1, 2, 3] } };
-        var expected = { complex: { foo: [1, 2, 3] } };
+        const attributes = { complex: { foo: [1, 3] } };
+        const base = { complex: { foo: [1, 2, 3] } };
+        const expected = { complex: { foo: [1, 2, 3] } };
         expect(AttributeMap.invert(attributes, base)).toEqual(expected);
       });
 
       it('deep change', function () {
-        var attributes = { complex: { foo: { bar: null } } };
-        var base = { complex: { foo: { bar: 123, baz: 456 } } };
-        var expected = { complex: { foo: { bar: 123 } } };
+        const attributes = { complex: { foo: { bar: null } } };
+        const base = { complex: { foo: { bar: 123, baz: 456 } } };
+        const expected = { complex: { foo: { bar: 123 } } };
         expect(AttributeMap.invert(attributes, base)).toEqual(expected);
       });
     });


### PR DESCRIPTION
At the moment, we have a bug when composing our custom "complex" attributes.

In general, if the `keepNull` flag is set to `false`, the resulting object should contain *no* `null` values. However, we can currently achieve this by composing together two complex objects, where one has a deeply-nested `null` key.

This is because we only check for `null` at the top of the tree when stripping values.

This change adds a check for all descendants of the attributes, and strips `null` out there, too.