### PR TITLE
💥 Remove `default` exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@reedsy/quill-delta",
-  "version": "5.1.0-reedsy.3.0.0",
+  "version": "5.1.0-reedsy.4.0.0",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",
-  "main": "dist/Delta.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
     "fast-diff": "1.3.0",

--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -134,4 +134,4 @@ namespace AttributeMap {
   }
 }
 
-export default AttributeMap;
+export { AttributeMap };

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -1,9 +1,9 @@
 import diff = require('fast-diff');
 import rfdc = require('rfdc');
 import isEqual = require('fast-deep-equal');
-import AttributeMap from './AttributeMap';
-import Op from './Op';
-import OpIterator from './OpIterator';
+import { AttributeMap } from './AttributeMap';
+import { Op } from './Op';
+import { OpIterator } from './OpIterator';
 const cloneDeep = rfdc();
 
 const NULL_CHARACTER = String.fromCharCode(0); // Placeholder char for embed in diff()
@@ -34,9 +34,6 @@ const getEmbedTypeAndData = (
 };
 
 class Delta {
-  static Op = Op;
-  static OpIterator = OpIterator;
-  static AttributeMap = AttributeMap;
   private static handlers: { [embedType: string]: EmbedHandler<unknown> } = {};
 
   static registerEmbed<T>(embedType: string, handler: EmbedHandler<T>): void {
@@ -564,11 +561,4 @@ class Delta {
   }
 }
 
-export default Delta;
-
-export { Op, OpIterator, AttributeMap };
-
-if (typeof module === 'object') {
-  module.exports = Delta;
-  module.exports.default = Delta;
-}
+export { Delta };

--- a/src/Op.ts
+++ b/src/Op.ts
@@ -1,4 +1,4 @@
-import AttributeMap from './AttributeMap';
+import { AttributeMap } from './AttributeMap';
 
 interface Op {
   // only one property out of {insert, delete, retain} will be present
@@ -23,4 +23,4 @@ namespace Op {
   }
 }
 
-export default Op;
+export { Op };

--- a/src/OpIterator.ts
+++ b/src/OpIterator.ts
@@ -1,6 +1,6 @@
-import Op from './Op';
+import { Op } from './Op';
 
-export default class Iterator {
+export class OpIterator {
   ops: Op[];
   index: number;
   offset: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+import { AttributeMap } from './AttributeMap';
+import { Delta } from './Delta';
+import { Op } from './Op';
+import { OpIterator } from './OpIterator';
+
+export { AttributeMap, Delta, Op, OpIterator };

--- a/test/attributes.ts
+++ b/test/attributes.ts
@@ -1,4 +1,4 @@
-import AttributeMap from '../src/AttributeMap';
+import { AttributeMap } from '../src/AttributeMap';
 
 describe('AttributeMap', () => {
   describe('compose()', () => {

--- a/test/delta/builder.ts
+++ b/test/delta/builder.ts
@@ -1,4 +1,4 @@
-import Delta from '../../src/Delta';
+import { Delta } from '../../src/Delta';
 
 describe('constructor', () => {
   const ops = [

--- a/test/delta/compose.ts
+++ b/test/delta/compose.ts
@@ -1,5 +1,5 @@
-import Delta from '../../src/Delta';
-import Op from '../../src/Op';
+import { Delta } from '../../src/Delta';
+import { Op } from '../../src/Op';
 
 describe('compose()', () => {
   it('insert + insert', () => {

--- a/test/delta/diff.ts
+++ b/test/delta/diff.ts
@@ -1,4 +1,4 @@
-import Delta from '../../src/Delta';
+import { Delta } from '../../src/Delta';
 
 describe('diff()', () => {
   it('insert', () => {

--- a/test/delta/helpers.ts
+++ b/test/delta/helpers.ts
@@ -1,4 +1,4 @@
-import Delta from '../../src/Delta';
+import { Delta } from '../../src/Delta';
 
 describe('helpers', () => {
   describe('concat()', () => {

--- a/test/delta/invert.ts
+++ b/test/delta/invert.ts
@@ -1,5 +1,5 @@
-import Delta from '../../src/Delta';
-import Op from '../../src/Op';
+import { Delta } from '../../src/Delta';
+import { Op } from '../../src/Op';
 
 describe('invert()', () => {
   it('insert', () => {

--- a/test/delta/transform-position.ts
+++ b/test/delta/transform-position.ts
@@ -1,4 +1,4 @@
-import Delta from '../../src/Delta';
+import { Delta } from '../../src/Delta';
 
 describe('transformPosition()', () => {
   it('insert before position', () => {

--- a/test/delta/transform.ts
+++ b/test/delta/transform.ts
@@ -1,5 +1,5 @@
-import Delta from '../../src/Delta';
-import Op from '../../src/Op';
+import { Delta } from '../../src/Delta';
+import { Op } from '../../src/Op';
 
 describe('transform()', () => {
   it('insert + insert', () => {

--- a/test/op-iterator.ts
+++ b/test/op-iterator.ts
@@ -1,5 +1,5 @@
-import Delta from '../src/Delta';
-import OpIterator from '../src/OpIterator';
+import { Delta } from '../src/Delta';
+import { OpIterator } from '../src/OpIterator';
 
 describe('OpIterator', () => {
   const delta = new Delta()

--- a/test/op.ts
+++ b/test/op.ts
@@ -1,4 +1,4 @@
-import { Op } from '../src/Delta';
+import { Op } from '../src/index';
 
 describe('Op', () => {
   describe('length()', () => {


### PR DESCRIPTION
`default` exports are badly behaved in ESM because their usage is ambiguous depending on the environment they're being imported into.

In order to improve CJS-ESM interoperability, this breaking change removes all default exports and uses only named exports.